### PR TITLE
Make environment variable for PROJ4 consistent with ecgate

### DIFF
--- a/configure
+++ b/configure
@@ -2080,9 +2080,9 @@ if test  -n "$proj_path"  ; then
   LIBS="-L${proj_path}/lib -Wl,-rpath,${proj_path}/lib ${LIBS}"
   PROJ_CPPFLAGS="-I. -I${proj_path}/include"
 else
-  if test  -n "${PROJ}"  ; then
-    LIBS="-L${PROJ}/lib -Wl,-rpath,${PROJ}/lib ${LIBS}"
-    PROJ_CPPFLAGS="-I. -I${PROJ}/include"
+  if test  -n "${PROJ4_DIR}"  ; then
+    LIBS="-L${PROJ4_DIR}/lib -Wl,-rpath,${PROJ4_DIR}/lib ${LIBS}"
+    PROJ_CPPFLAGS="-I. -I${PROJ4_DIR}/include"
   fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -33,9 +33,9 @@ if test [ -n "$proj_path" ] ; then
   LIBS="-L${proj_path}/lib -Wl,-rpath,${proj_path}/lib ${LIBS}"
   PROJ_CPPFLAGS="-I. -I${proj_path}/include"
 else
-  if test [ -n "${PROJ}" ] ; then
-    LIBS="-L${PROJ}/lib -Wl,-rpath,${PROJ}/lib ${LIBS}"
-    PROJ_CPPFLAGS="-I. -I${PROJ}/include"
+  if test [ -n "${PROJ4_DIR}" ] ; then
+    LIBS="-L${PROJ4_DIR}/lib -Wl,-rpath,${PROJ4_DIR}/lib ${LIBS}"
+    PROJ_CPPFLAGS="-I. -I${PROJ4_DIR}/include"
   fi
 fi
 


### PR DESCRIPTION
ecgate uses PROJ4_DIR as the environment variable for the proj4 directory. This PR ensures that meteogrid can be installed on ecgate once module load proj4 has been executed. 